### PR TITLE
Fixed spacing in title tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Railsgirls</title>
+    <title>Rails Girls</title>
     <%= csrf_meta_tags %>
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap-theme.css">


### PR DESCRIPTION
Hey Julia,

I noticed that the application layout still had the default "Railsgirls" in the title tag, so I fixed it so that it looks a bit nicer for our users <3

Matt
